### PR TITLE
Zip fastboot build into `dist`-folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = {
         let archivePath = path.join(fastbootDistDir, archiveName);
 
         let zip = new AdmZip();
-        zip.addLocalFolder(distDir);
+        zip.addLocalFolder(distDir, 'dist');
         zip.writeZip(archivePath);
 
         return {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -148,7 +148,7 @@ describe('fastboot-app-server plugin', function() {
         let zip = new AdmZip('tmp/fastboot-deploy/dist-1234.zip');
         zip.extractAllTo('tmp/fastboot-deploy', true);
 
-        let deployText = fs.readFileSync('tmp/fastboot-deploy/deploy.txt')
+        let deployText = fs.readFileSync('tmp/fastboot-deploy/dist/deploy.txt')
 
         assert.equal(deployText, 'deployment');
       });


### PR DESCRIPTION
The release version of s3-downloader expects this to be this way
so we will zip to `dist`.

cc @ghedamat 