### PR TITLE
Prevent compression on files that can’t be DEFLATED

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,13 @@ module.exports = {
 
         let zip = new AdmZip();
         zip.addLocalFolder(distDir, 'dist');
+
+        // remove compression since certain files can't be DEFLATED
+        // such as .png, .jpg, .eot, etc.
+        zip.getEntries().forEach(function(currentValue) {
+          currentValue.header.method = 0;
+        });
+
         zip.writeZip(archivePath);
 
         return {


### PR DESCRIPTION
I had the same problems unzipping the output mentioned in issue #3.

Then I discovered [ember-cli-deploy-zip](https://github.com/aesopwolf/ember-cli-deploy-zip) also uses [adm-zip](https://github.com/cthackers/adm-zip) with exactly the same version, but this zipped my dist with no problems at all.

The difference is found [here](https://github.com/aesopwolf/ember-cli-deploy-zip/blob/5e5657621daf0954a3711ea56ef5993ed3a5f076/index.js#L48) which I simply copied, this solved all my problems.