### PR TITLE
adds option ignoreFiles, which allows to ignore certain files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ The prefix that will be used in combination with a revisionkey to build up the i
 
 *Default:* `dist-`
 
+### ignoreFiles
+
+Allows to specify a glob pattern to exclude certain files. To exclude all `*.map` files, set it to `"**/*.map"`.
+
+*Default"* `undefined`
+
 ### fastbootDownloaderManifestContent
 
 A function that gets added to the deploy context so that other plugins can update an app-manifest file that is used by [fastboot-app-server notifiers](https://github.com/ember-fastboot/fastboot-app-server#notifiers) and [-downloaders](https://github.com/ember-fastboot/fastboot-app-server#downloaders) to update the FastBoot-app served via `fastboot-app-server`.

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ module.exports = {
         let distDir               = this.readConfig('distDir');
         let revisionKey           = this.readConfig('revisionKey');
         let fastbootDistDir       = this.readConfig('fastbootDistDir');
+        let ignoreFiles           = this.readConfig('ignoreFiles');
         let fastbootArchivePrefix = context.fastbootArchivePrefix;
 
         if (!fs.existsSync(fastbootDistDir)) {
@@ -76,9 +77,18 @@ module.exports = {
         let output = fs.createWriteStream(archivePath);
 
         zip.pipe(output);
+        if (ignoreFiles) {
+          zip.glob("**/*", {
+            cwd: distDir,
+            ignore: ignoreFiles
+          }, {
+            prefix: '/dist/'
+          });
+        } else {
+          zip.directory(distDir, 'dist');
+        }
 
         return zip
-          .directory(distDir, 'dist')
           .finalize()
           .then(() => {
             return {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -169,7 +169,7 @@ describe('fastboot-app-server plugin', function() {
       });
     });
 
-    describe('#didPrepare/globPattern', function() {
+    describe('#didPrepare/globPattern - ignore all .map files', function() {
       beforeEach(function() {
         context.config['fastboot-app-server'].ignoreFiles = "**/*.map";
         plugin.configure(context);
@@ -197,7 +197,7 @@ describe('fastboot-app-server plugin', function() {
           });
       });
 
-      it('globPattern option zips the content of distDir as expected', function() {
+      it('compressed zip should not contain any .map files - all other files should be included', function() {
         return plugin.didPrepare(context)
           .then(() => {
             return decompress('tmp/fastboot-deploy/dist-1234.zip', 'tmp/fastboot-deploy');

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -206,8 +206,8 @@ describe('fastboot-app-server plugin', function() {
             let deployText = fs.readFileSync('tmp/fastboot-deploy/dist/deploy.txt')
 
             assert.equal(deployText, 'deployment');
-            assert.ok(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.js'));
-            assert.notOk(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.map'));
+            assert.ok(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.js'), 'app.js is included in zipped files');
+            assert.notOk(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.map'), 'app.map is not included in zipped files');
           })
       });
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -134,6 +134,9 @@ describe('fastboot-app-server plugin', function() {
 
         mkdirp.sync(DIST_DIR);
         fs.writeFileSync(`${DIST_DIR}/deploy.txt`, 'deployment');
+        mkdirp.sync(`${DIST_DIR}/assets`);
+        fs.writeFileSync(`${DIST_DIR}/assets/app.js`, 'deployment');
+        fs.writeFileSync(`${DIST_DIR}/assets/app.map`, 'deployment');
       });
 
       it('zips the contents of `distDir` and writes them to `fastbootDistDir` as a zip tagged by `revisionKey`', function() {
@@ -152,6 +155,59 @@ describe('fastboot-app-server plugin', function() {
             let deployText = fs.readFileSync('tmp/fastboot-deploy/dist/deploy.txt')
 
             assert.equal(deployText, 'deployment');
+            assert.ok(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.js'));
+            assert.ok(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.map'));
+          })
+      });
+
+      it('adds fastbootArchiveName and fastbootArchivePath info to the deplyoment context', function() {
+        return plugin.didPrepare(context)
+          .then((info) => {
+            assert.equal(info.fastbootArchiveName, 'dist-1234.zip');
+            assert.equal(info.fastbootArchivePath, 'tmp/fastboot-deploy/dist-1234.zip');
+          });
+      });
+    });
+
+    describe('#didPrepare/globPattern', function() {
+      beforeEach(function() {
+        context.config['fastboot-app-server'].ignoreFiles = "**/*.map";
+        plugin.configure(context);
+
+        let DIST_DIR = 'tmp/deploy-dist'
+        rimraf.sync('tmp');
+
+        context.fastbootArchivePrefix = 'dist-';
+        context.distDir = DIST_DIR;
+        context.revisionData = {
+          revisionKey: '1234'
+        };
+
+        mkdirp.sync(DIST_DIR);
+        fs.writeFileSync(`${DIST_DIR}/deploy.txt`, 'deployment');
+        mkdirp.sync(`${DIST_DIR}/assets`);
+        fs.writeFileSync(`${DIST_DIR}/assets/app.js`, 'deployment');
+        fs.writeFileSync(`${DIST_DIR}/assets/app.map`, 'deployment');
+      });
+
+      it('zips the contents of `distDir` and writes them to `fastbootDistDir` as a zip tagged by `revisionKey`', function() {
+        return plugin.didPrepare(context)
+          .then(() => {
+            assert.ok(fs.existsSync('tmp/fastboot-deploy/dist-1234.zip'));
+          });
+      });
+
+      it('globPattern option zips the content of distDir as expected', function() {
+        return plugin.didPrepare(context)
+          .then(() => {
+            return decompress('tmp/fastboot-deploy/dist-1234.zip', 'tmp/fastboot-deploy');
+          })
+          .then(() => {
+            let deployText = fs.readFileSync('tmp/fastboot-deploy/dist/deploy.txt')
+
+            assert.equal(deployText, 'deployment');
+            assert.ok(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.js'));
+            assert.notOk(fs.existsSync('tmp/fastboot-deploy/dist/assets/app.map'));
           })
       });
 


### PR DESCRIPTION
Useful for instance, if you don't want your FastBoot zip to contain sourcemaps

Current behaviour is maintained if nothing is specified for `ignoreFIles`